### PR TITLE
Fix dao.conf lookup

### DIFF
--- a/config/dao.conf
+++ b/config/dao.conf
@@ -1,0 +1,1 @@
+boards/arm/dao/dao.conf


### PR DESCRIPTION
Currently dao.conf gets ignored.

According to the documentation:

> Shared config files (excluding any _left or _right suffix) are not currently supported in board folders.

So, adding a symbolic link to the User Config Folder fixes the problem and the dao.conf gets detected and used by the build.