### PR TITLE
Update west.yml

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
       import: app/west.yml
     - name: ergonautkb-zmk-module
       remote: ergonautkb


### PR DESCRIPTION
with
```yml
    - name: zmk
      remote: zmkfirmware
      revision: main
```
the build workflow is broken with `revision: main` in `west.yaml`. Works fine with `revision: v0.3`
